### PR TITLE
Add a memory recorder and error reporter func

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,8 @@
-FROM golang:1.4.2
-MAINTAINER Sanjay R <sanjay@remind101.com>
-
-RUN apt-get update && apt-get install -y \
-    libboost-all-dev libcurl4-openssl-dev \
-    --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /go/src/github.com/remind101/newrelic
-WORKDIR /go/src/github.com/remind101/newrelic
-
-CMD ["/go/bin/app"]
+FROM remind101/go:1.4-newrelic
 
 COPY . /go/src/github.com/remind101/newrelic
 
-# Copy newrelic agent sdk lib and headers
-RUN curl http://download.newrelic.com/agent_sdk/nr_agent_sdk-v0.16.1.0-beta.x86_64.tar.gz | tar zx && \
-    mkdir -p /usr/local/lib && \
-    cp nr_agent_sdk-v0.16.1.0-beta.x86_64/lib/* /usr/local/lib && \
-    mkdir -p /usr/local/include && \
-    cp nr_agent_sdk-v0.16.1.0-beta.x86_64/include/* /usr/local/include && \
-    ldconfig
+WORKDIR /go/src/github.com/remind101/newrelic
 
 RUN go-wrapper download -tags newrelic_enabled ./...
-
 RUN go-wrapper install -tags newrelic_enabled ./...

--- a/newrelic.go
+++ b/newrelic.go
@@ -23,12 +23,15 @@ type TxTracer interface {
 	SetTransactionName(txnID int64, name string) error
 	SetTransactionRequestURL(txnID int64, url string) error
 
-	ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error)
-
 	BeginGenericSegment(txnID int64, parentID int64, name string) (int64, error)
 	BeginDatastoreSegment(txnID int64, parentID int64, table string, operation string, sql string, rollupName string) (int64, error)
 	BeginExternalSegment(txnID int64, parentID int64, host string, name string) (int64, error)
 	EndSegment(txnID int64, parentID int64) error
+}
+
+// TxReporter reports the first error that occured during a transaction.
+type TxReporter interface {
+	ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error)
 }
 
 // Recorder handles metrics recording.

--- a/newrelic.go
+++ b/newrelic.go
@@ -2,24 +2,52 @@ package newrelic
 
 import (
 	"errors"
+	"time"
 )
 
 var ErrTxAlreadyStarted = errors.New("transaction already started")
 
 type Agent interface {
+	Recorder
 	TxTracer
 	Init(license string, appName string, lang string, langVersion string) error
+	EnableInstrumentation(enabled bool)
 	RequestShutdown(reason string) error
-	RecordMetric(name string, val float64) error
 }
 
+// TxTracer handles transaction tracing.
 type TxTracer interface {
 	BeginTransaction() (int64, error)
+	EndTransaction(txnID int64) error
+
 	SetTransactionName(txnID int64, name string) error
+	SetTransactionRequestURL(txnID int64, url string) error
+
+	ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error)
+
 	BeginGenericSegment(txnID int64, parentID int64, name string) (int64, error)
 	BeginDatastoreSegment(txnID int64, parentID int64, table string, operation string, sql string, rollupName string) (int64, error)
 	BeginExternalSegment(txnID int64, parentID int64, host string, name string) (int64, error)
 	EndSegment(txnID int64, parentID int64) error
-	SetTransactionRequestURL(txnID int64, url string) error
-	EndTransaction(txnID int64) error
+}
+
+// Recorder handles metrics recording.
+type Recorder interface {
+	Interval() time.Duration
+	Record() error
+}
+
+// RecordMetrics records metrics with the default metric recorder.
+func RecordMetrics(interval time.Duration) {
+	RecordMetricsWithRecorder(newRecorder(interval))
+}
+
+// RecordMetricsWithRecorder records metrics with the given recorder.
+func RecordMetricsWithRecorder(r Recorder) {
+	ticker := time.NewTicker(r.Interval())
+	go func() {
+		for range ticker.C {
+			r.Record()
+		}
+	}()
 }

--- a/newrelic.go
+++ b/newrelic.go
@@ -7,14 +7,6 @@ import (
 
 var ErrTxAlreadyStarted = errors.New("transaction already started")
 
-type Agent interface {
-	Recorder
-	TxTracer
-	Init(license string, appName string, lang string, langVersion string) error
-	EnableInstrumentation(enabled bool)
-	RequestShutdown(reason string) error
-}
-
 // TxTracer handles transaction tracing.
 type TxTracer interface {
 	BeginTransaction() (int64, error)

--- a/recorder_newrelic_disabled.go
+++ b/recorder_newrelic_disabled.go
@@ -1,0 +1,21 @@
+// +build !newrelic_enabled
+
+package newrelic
+
+import "time"
+
+type recorder struct {
+	interval time.Duration
+}
+
+func newRecorder(interval time.Duration) *recorder {
+	return &recorder{interval: interval}
+}
+
+func (r *recorder) Interval() time.Duration {
+	return r.interval
+}
+
+func (r *recorder) Record() error {
+	return nil
+}

--- a/recorder_newrelic_enabled.go
+++ b/recorder_newrelic_enabled.go
@@ -1,0 +1,36 @@
+// +build newrelic_enabled
+
+package newrelic
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/remind101/newrelic/sdk"
+)
+
+// recorder is the default implementation of the Recorder interface. It
+// records CPU and Memory metrics.
+type recorder struct {
+	interval time.Duration
+}
+
+func newRecorder(interval time.Duration) *recorder {
+	return &recorder{interval: interval}
+}
+
+func (r *recorder) Interval() time.Duration {
+	return r.interval
+}
+
+func (r *recorder) Record() error {
+	return recordMemory()
+}
+
+func recordMemory() error {
+	m := &runtime.MemStats{}
+	runtime.ReadMemStats(m)
+	mb := float64(m.Alloc) / (1024 * 1024)
+	_, err := sdk.RecordMemoryUsage(mb)
+	return err
+}

--- a/reporter_newrelic_disabled.go
+++ b/reporter_newrelic_disabled.go
@@ -1,0 +1,9 @@
+// +build !newrelic_enabled
+
+package newrelic
+
+type NRTxReporter struct{}
+
+func (r *NRTxReporter) ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error) {
+	return 0, nil
+}

--- a/reporter_newrelic_enabled.go
+++ b/reporter_newrelic_enabled.go
@@ -1,0 +1,9 @@
+// +build newrelic_enabled
+
+package newrelic
+
+type NRTxReporter struct{}
+
+func (r *NRTxReporter) ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error) {
+	return sdk.TransactionNoticeError(txnID, exceptionType, errorMessage, stackTrace, stackFrameDelim)
+}

--- a/reporter_newrelic_enabled.go
+++ b/reporter_newrelic_enabled.go
@@ -2,6 +2,10 @@
 
 package newrelic
 
+import (
+	"github.com/remind101/newrelic/sdk"
+)
+
 type NRTxReporter struct{}
 
 func (r *NRTxReporter) ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error) {

--- a/tracer_newrelic_disabled.go
+++ b/tracer_newrelic_disabled.go
@@ -18,24 +18,27 @@ type NRTxTracer struct{}
 func (t *NRTxTracer) BeginTransaction() (int64, error) {
 	return 0, nil
 }
-func (t *NRTxTracer) SetTransactionName(txnID int64, name string) error {
+func (t *NRTxTracer) EndTransaction(txnID int64) error {
 	return nil
 }
-func (t *NRTxTracer) BeginGenericSegment(txnID int64, parentID int64, name string) (int64, error) {
-	return 0, nil
-}
-func (t *NRTxTracer) BeginDatastoreSegment(txnID int64, parentID int64, table string, operation string, sql string, rollupName string) (int64, error) {
-	return 0, nil
-}
-func (t *NRTxTracer) BeginExternalSegment(txnID int64, parentID int64, host string, name string) (int64, error) {
-	return 0, nil
-}
-func (t *NRTxTracer) EndSegment(txnID int64, parentID int64) error {
+func (t *NRTxTracer) SetTransactionName(txnID int64, name string) error {
 	return nil
 }
 func (t *NRTxTracer) SetTransactionRequestURL(txnID int64, url string) error {
 	return nil
 }
-func (t *NRTxTracer) EndTransaction(txnID int64) error {
+func (t *NRTxTracer) ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error) {
+	return 0, nil
+}
+func (t *NRTxTracer) BeginGenericSegment(txnID, parentID int64, name string) (int64, error) {
+	return 0, nil
+}
+func (t *NRTxTracer) BeginDatastoreSegment(txnID, parentID int64, table, operation, sql, rollupName string) (int64, error) {
+	return 0, nil
+}
+func (t *NRTxTracer) BeginExternalSegment(txnID, parentID int64, host, name string) (int64, error) {
+	return 0, nil
+}
+func (t *NRTxTracer) EndSegment(txnID, parentID int64) error {
 	return nil
 }

--- a/tracer_newrelic_disabled.go
+++ b/tracer_newrelic_disabled.go
@@ -27,9 +27,6 @@ func (t *NRTxTracer) SetTransactionName(txnID int64, name string) error {
 func (t *NRTxTracer) SetTransactionRequestURL(txnID int64, url string) error {
 	return nil
 }
-func (t *NRTxTracer) ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error) {
-	return 0, nil
-}
 func (t *NRTxTracer) BeginGenericSegment(txnID, parentID int64, name string) (int64, error) {
 	return 0, nil
 }

--- a/tracer_newrelic_enabled.go
+++ b/tracer_newrelic_enabled.go
@@ -22,9 +22,6 @@ func (t *NRTxTracer) SetTransactionName(txnID int64, name string) error {
 	_, err := sdk.TransactionSetName(txnID, name)
 	return err
 }
-func (t *NRTxTracer) ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error) {
-	return sdk.TransactionNoticeError(txnID, exceptionType, errorMessage, stackTrace, stackFrameDelim)
-}
 func (t *NRTxTracer) BeginGenericSegment(txnID, parentID int64, name string) (int64, error) {
 	return sdk.SegmentGenericBegin(txnID, parentID, name)
 }

--- a/tracer_newrelic_enabled.go
+++ b/tracer_newrelic_enabled.go
@@ -22,16 +22,19 @@ func (t *NRTxTracer) SetTransactionName(txnID int64, name string) error {
 	_, err := sdk.TransactionSetName(txnID, name)
 	return err
 }
-func (t *NRTxTracer) BeginGenericSegment(txnID int64, parentID int64, name string) (int64, error) {
+func (t *NRTxTracer) ReportError(txnID int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) (int, error) {
+	return sdk.TransactionNoticeError(txnID, exceptionType, errorMessage, stackTrace, stackFrameDelim)
+}
+func (t *NRTxTracer) BeginGenericSegment(txnID, parentID int64, name string) (int64, error) {
 	return sdk.SegmentGenericBegin(txnID, parentID, name)
 }
-func (t *NRTxTracer) BeginDatastoreSegment(txnID int64, parentID int64, table string, operation string, sql string, rollupName string) (int64, error) {
+func (t *NRTxTracer) BeginDatastoreSegment(txnID, parentID int64, table, operation, sql, rollupName string) (int64, error) {
 	return sdk.SegmentDatastoreBegin(txnID, parentID, table, operation, sql, rollupName)
 }
-func (t *NRTxTracer) BeginExternalSegment(txnID int64, parentID int64, host string, name string) (int64, error) {
+func (t *NRTxTracer) BeginExternalSegment(txnID, parentID int64, host, name string) (int64, error) {
 	return sdk.SegmentExternalBegin(txnID, parentID, host, name)
 }
-func (t *NRTxTracer) EndSegment(txnID int64, parentID int64) error {
+func (t *NRTxTracer) EndSegment(txnID, parentID int64) error {
 	_, err := sdk.SegmentEnd(txnID, parentID)
 	return err
 }

--- a/tx.go
+++ b/tx.go
@@ -111,6 +111,12 @@ func (t *tx) EndSegment() error {
 	return nil
 }
 
+// ReportError reports an error that occured during the transaction.
+func (t *tx) ReportError(exceptionType, errorMessage, stackTrace, stackFrameDelim string) error {
+	_, err := t.Tracer.ReportError(t.id, exceptionType, errorMessage, stackTrace, stackFrameDelim)
+	return err
+}
+
 // WithTx inserts a newrelic.Tx into the provided context.
 func WithTx(ctx context.Context, t Tx) context.Context {
 	return context.WithValue(ctx, txKey, t)

--- a/tx.go
+++ b/tx.go
@@ -12,8 +12,10 @@ type Tx interface {
 	EndSegment() error
 }
 
+// tx implements the Tx interface.
 type tx struct {
-	Tracer TxTracer
+	Tracer   TxTracer
+	Reporter TxReporter
 
 	id   int64
 	name string
@@ -22,28 +24,20 @@ type tx struct {
 }
 
 // NewTx returns a new transaction.
-func NewTx(name string, tracer TxTracer) Tx {
-	if tracer == nil {
-		tracer = &NRTxTracer{}
-	}
+func NewTx(name string) *tx {
 	return &tx{
-		Tracer: tracer,
-		name:   name,
-		ss:     NewSegmentStack(),
+		Tracer:   &NRTxTracer{},
+		Reporter: &NRTxReporter{},
+		name:     name,
+		ss:       NewSegmentStack(),
 	}
 }
 
 // NewRequestTx returns a new transaction with a request url.
-func NewRequestTx(name string, url string, tracer TxTracer) Tx {
-	if tracer == nil {
-		tracer = &NRTxTracer{}
-	}
-	return &tx{
-		Tracer: tracer,
-		name:   name,
-		url:    url,
-		ss:     NewSegmentStack(),
-	}
+func NewRequestTx(name string, url string) *tx {
+	t := NewTx(name)
+	t.url = url
+	return t
 }
 
 // Start starts a transaction, setting the id.
@@ -113,7 +107,7 @@ func (t *tx) EndSegment() error {
 
 // ReportError reports an error that occured during the transaction.
 func (t *tx) ReportError(exceptionType, errorMessage, stackTrace, stackFrameDelim string) error {
-	_, err := t.Tracer.ReportError(t.id, exceptionType, errorMessage, stackTrace, stackFrameDelim)
+	_, err := t.Reporter.ReportError(t.id, exceptionType, errorMessage, stackTrace, stackFrameDelim)
 	return err
 }
 

--- a/tx.go
+++ b/tx.go
@@ -10,6 +10,7 @@ type Tx interface {
 	StartDatastore(table, operation, sql, rollupName string) error
 	StartExternal(host, name string) error
 	EndSegment() error
+	ReportError(exceptionType, errorMessage, stackTrace, stackFrameDelim string) error
 }
 
 // tx implements the Tx interface.


### PR DESCRIPTION
This adds two new interfaces `TxReporter` and `Recorder`.

Recorder is for Recording metrics (default implementation records memory usage).

TxReporter is for reporting errors during transactions.

I also simplified the `NewTx` funcs. If you want to swap out a Tracer or Reporter you can just `tx.Tracer = MyTracer` after `NewTx(...)`