### PR TITLE
Use CFLAGS and SRCDIR for custom headers

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -3,6 +3,7 @@
 package sdk
 
 // #cgo LDFLAGS: -L/usr/local/lib -lnewrelic-collector-client -lnewrelic-common -lnewrelic-transaction
+// #cgo CFLAGS: -I ${SRCDIR}/../include
 // #include "newrelic_collector_client.h"
 // #include "newrelic_common.h"
 // #include "newrelic_transaction.h"

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -3,7 +3,7 @@
 package sdk
 
 // #cgo LDFLAGS: -L/usr/local/lib -lnewrelic-collector-client -lnewrelic-common -lnewrelic-transaction
-// #cgo CFLAGS: -I ${SRCDIR}/../include
+// #cgo go1.5 CFLAGS: -I ${SRCDIR}/../include
 // #include "newrelic_collector_client.h"
 // #include "newrelic_common.h"
 // #include "newrelic_transaction.h"


### PR DESCRIPTION
This is a nice way to tell CGO where to find this project's custom newrelic headers.